### PR TITLE
業務1コピーと更新ボタンを縦並びに変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,9 +30,11 @@
             <div class="main-buttons">
                 <button id="submit-button">入力確認</button>
                 <button id="email-button">メール作成</button>
+            </div>
+            <div class="side-buttons">
+                <button id="refresh-button">更新</button>
                 <button id="copy-task1-button">業務1コピー</button>
             </div>
-            <button id="refresh-button">更新</button>
         </div>
         <div id="result" class="result"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -82,6 +82,13 @@ button:hover {
     font-size: 1em; /* 文字サイズを調整 */
 }
 
+#copy-task1-button {
+    width: 60px;
+    height: 40px;
+    padding: 0;
+    font-size: 1em;
+}
+
 .button-group {
     display: flex;
     justify-content: space-between;
@@ -90,9 +97,15 @@ button:hover {
   
 .main-buttons {
     display: grid; /* Gridレイアウトを使用 */
-    grid-template-columns: 1fr 1fr 1fr; /* 3つのカラムを均等に */
+    grid-template-columns: 1fr 1fr; /* 2つのカラムを均等に */
     gap: 10px; /* ボタン間のスペース */
     width: 100%; /* 親要素の幅いっぱいに広げる */
+}
+
+.side-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 }
   
 .button-group button {
@@ -103,4 +116,8 @@ button:hover {
 #refresh-button {
     /* 更新ボタンのスタイル */
     padding: 5px; /* 小さくする */
+}
+
+#copy-task1-button {
+    padding: 5px; /* 更新ボタンと同じ余白 */
 }


### PR DESCRIPTION
## Summary
- コピー専用ボタンを更新ボタンと並べて縦に配置
- サイドボタン用スタイルを追加
- 業務1コピーを更新ボタンと同じサイズに調整

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b207245f8832eaa9a46c280c43b7f