### PR TITLE
更新ボタンと業務1コピーのサイズ調整

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         <div style="padding-right: 20px;">
             <a href="https://forms.gle/fbZW4GG91BBKUmkc9" target="_blank">アンケートはこちら</a>
         </div>
-        <span>ver.0.9d</span>
+        <span>ver.0.9e</span>
     </div>
 
     <script src="scripts.js"></script>

--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
             "type": "image/png"
         }
     ],
-    "version": "0.8.3"
+    "version": "0.8.4"
 }

--- a/styles.css
+++ b/styles.css
@@ -75,20 +75,16 @@ button:hover {
     color: white;
 }
 
-#refresh-button {
-    width: 60px; /* 固定幅 */
-    height: 40px; /* 固定高さ */
-    padding: 5px; /* ボタンを少し小さく表示 */
-    font-size: 1em; /* 文字サイズを調整 */
-}
-
+#refresh-button,
 #copy-task1-button {
     width: 100px; /* 横幅を広げて折り返しを防ぐ */
-    height: 55px;
-    line-height: 55px;
+    height: 55px; /* 統一した高さ */
+    line-height: 55px; /* テキストを中央寄せ */
     padding: 0;
     font-size: 1em;
     white-space: nowrap; /* 文字を折り返さない */
+    margin-top: 5px;
+    margin-bottom: 5px;
 }
 
 .button-group {
@@ -107,7 +103,7 @@ button:hover {
 .side-buttons {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 5px;
 }
   
 .button-group button {


### PR DESCRIPTION
## 変更内容
- `#refresh-button` と `#copy-task1-button` のスタイルを共通化し、同じ幅・高さに統一
- サイドボタンの `gap` を 5px に変更し、上下の余白を半分に調整
- バージョンを `index.html` は `ver.0.9e`、`manifest.json` は `0.8.4` へ更新

## テスト結果
- 自動テストはありません。ローカル環境で表示を確認してください。

------
https://chatgpt.com/codex/tasks/task_e_684d35861cb8832e9a39bb4ad18b0054