### PR TITLE
Add CSV download option

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         <div style="padding-right: 20px;">
             <a href="https://forms.gle/fbZW4GG91BBKUmkc9" target="_blank">アンケートはこちら</a>
         </div>
-        <span>ver.0.9e</span>
+        <span>ver.0.9f</span>
     </div>
 
     <script src="scripts.js"></script>

--- a/logs.html
+++ b/logs.html
@@ -23,10 +23,30 @@
             word-wrap: break-word;
             margin-bottom: 6px;
         }
+        button {
+            padding: 6px 14px;
+            font-size: 15px;
+            margin-top: 10px;
+            width: 100%;
+            box-sizing: border-box;
+            background-color: #333;
+            color: white;
+            border: 1px solid #aaa;
+            border-radius: 5px;
+            cursor: pointer;
+            transition: background 0.2s;
+            white-space: nowrap;
+        }
+        button:hover {
+            background-color: #3a4d57;
+        }
+        button:active {
+            background: #e0e0e0;
+        }
         .actions {
             margin-top: 20px;
             display: flex;
-            justify-content: space-between;
+            gap: 8px;
         }
     </style>
 </head>
@@ -37,6 +57,7 @@
         <div class="actions">
             <a href="index.html">戻る</a>
             <button id="clear-logs">ログをクリア</button>
+            <button id="download-logs">CSVダウンロード</button>
         </div>
     </div>
     <script>
@@ -56,6 +77,22 @@
             localStorage.removeItem('logs');
             logList.innerHTML = '<li>ログはありません</li>';
         });
+        document.getElementById('download-logs').addEventListener('click', downloadLogs);
+
+        function downloadLogs() {
+            const csv = localStorage.getItem('logs');
+            if (!csv) {
+                alert('ログはありません');
+                return;
+            }
+            const blob = new Blob([csv], { type: 'text/csv' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'logs.csv';
+            a.click();
+            URL.revokeObjectURL(url);
+        }
     });
     </script>
 </body>

--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
             "type": "image/png"
         }
     ],
-    "version": "0.8.4"
+    "version": "0.8.5"
 }


### PR DESCRIPTION
## Summary
- add a `CSVダウンロード` button to logs.html
- style log page buttons to match the rest of the app
- implement `downloadLogs` to export logs from localStorage
- bump version strings

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d4f8eff30832e9c434bb759fa2060