### PR TITLE
Add pattern-based task number copying

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         <div style="padding-right: 20px;">
             <a href="https://forms.gle/fbZW4GG91BBKUmkc9" target="_blank">アンケートはこちら</a>
         </div>
-        <span>ver.0.9e</span>
+        <span>ver.0.9f</span>
     </div>
 
     <script src="scripts.js"></script>

--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
             "type": "image/png"
         }
     ],
-    "version": "0.8.4"
+    "version": "0.8.5"
 }

--- a/scripts.js
+++ b/scripts.js
@@ -135,14 +135,29 @@ document.addEventListener('DOMContentLoaded', function() {
         }, 1500);
     });
 
+    function getFormat(str) {
+        return Array.from(str).map(ch => {
+            if (/[A-Za-z]/.test(ch)) {
+                return 'A';
+            } else if (/[0-9]/.test(ch)) {
+                return '0';
+            }
+            return ch;
+        }).join('');
+    }
+
     // 業務1を他の業務番号にコピーするボタン
     copyTask1Button.addEventListener('click', function() {
         const selectedCount = parseInt(groupCountPicker.value, 10);
         const taskNumber1 = document.getElementById('task-number1').value;
+        const format1 = getFormat(taskNumber1);
         for (let i = 2; i <= selectedCount; i++) {
             const field = document.getElementById(`task-number${i}`);
             if (field) {
-                field.value = taskNumber1;
+                const fieldFormat = getFormat(field.value);
+                if (field.value === '' || fieldFormat === format1) {
+                    field.value = taskNumber1;
+                }
             }
         }
         saveTaskData();


### PR DESCRIPTION
## Summary
- add `getFormat` helper to convert strings to format patterns
- copy task numbers only when formats match or the destination is empty
- bump version numbers in HTML and manifest

## Testing
- `grep -n getFormat scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_684d4f9bda18832ea091d7ee87161e14