### PR TITLE
manifestのバージョンを統一

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
             "type": "image/png"
         }
     ],
-    "version": "0.8.5"
+    "version": "0.9f"
 }


### PR DESCRIPTION
## 変更概要
- `manifest.json` の `version` を `0.9f` に更新し、`index.html` の表示と揃えました
- 前回追加した CSV ダウンロード機能に伴うバージョン番号の不整合を解消しました

## テスト結果
- 自動テスト環境がないため、ビルドやブラウザ表示の確認は行っていません

------
https://chatgpt.com/codex/tasks/task_e_685020e39b70832eadeeca3243f04981