### PR TITLE
ログ画面のUI改善

### DIFF
--- a/logs.html
+++ b/logs.html
@@ -69,7 +69,11 @@
 <body>
     <div class="container">
         <h1>ログ表示</h1>
-        <ul id="log-list"></ul>
+        <div class="actions">
+            <a href="index.html">戻る</a>
+            <button id="clear-logs" class="small">ログをクリア</button>
+            <button id="download-logs" class="small">CSVダウンロード</button>
+        </div>
         <h2>月別集計</h2>
         <div id="monthly-summary-section">
             <label for="summary-month">集計対象年月:</label>
@@ -77,22 +81,24 @@
             <button id="show-summary" class="small">集計表示</button>
             <div id="monthly-summary"></div>
         </div>
-        <div class="actions">
-            <a href="index.html">戻る</a>
-            <button id="clear-logs" class="small">ログをクリア</button>
-            <button id="download-logs" class="small">CSVダウンロード</button>
-        </div>
+        <ul id="log-list"></ul>
     </div>
     <script>
     document.addEventListener('DOMContentLoaded', function () {
         const logList = document.getElementById('log-list');
+        const summaryMonth = document.getElementById('summary-month');
+        const now = new Date();
+        summaryMonth.value = now.toISOString().slice(0, 7);
         const data = localStorage.getItem('logs');
         if (data) {
-            data.split('\n').forEach(line => {
-                const li = document.createElement('li');
-                li.textContent = line;
-                logList.appendChild(li);
-            });
+            data.split('\n')
+                .filter(l => l)
+                .sort((a, b) => new Date(b.split(',')[0]) - new Date(a.split(',')[0]))
+                .forEach(line => {
+                    const li = document.createElement('li');
+                    li.textContent = line;
+                    logList.appendChild(li);
+                });
         } else {
             logList.innerHTML = '<li>ログはありません</li>';
         }


### PR DESCRIPTION
## Summary
- 月別集計と操作ボタンを画面上部へ移動
- 月表示ピッカーの初期値を現在月に設定
- ログ表示を新しい順になるよう変更

## Testing
- `node test/test.js`


------
https://chatgpt.com/codex/tasks/task_e_6850316d5940832e97cf03da13a0767a