### PR TITLE
自動集計表示の実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         <div style="padding-right: 20px;">
             <a href="https://forms.gle/fbZW4GG91BBKUmkc9" target="_blank">アンケートはこちら</a>
         </div>
-        <span>ver.0.9j</span>
+        <span>ver.0.9k</span>
     </div>
 
     <script src="scripts.js"></script>

--- a/logs.html
+++ b/logs.html
@@ -78,8 +78,6 @@
         <div id="monthly-summary-section">
             <label for="summary-month">集計対象年月:</label>
             <input type="month" id="summary-month">
-            <button id="show-summary" class="small">集計表示</button>
-            <div id="monthly-summary"></div>
         </div>
         <table id="log-table" style="width:100%; border-collapse: collapse;">
             <thead>
@@ -91,7 +89,9 @@
                     <th style="border-bottom:1px solid #ccc; text-align:left;">残業時間</th>
                 </tr>
             </thead>
-            <tbody id="log-body"></tbody>
+            <tbody id="log-body">
+                <tr id="summary-row"><td id="monthly-summary" colspan="5"></td></tr>
+            </tbody>
         </table>
     </div>
     <script>
@@ -126,7 +126,9 @@
         document.getElementById('clear-logs').addEventListener('click', function () {
             if (confirm('ログをクリアしますか？')) {
                 localStorage.removeItem('logs');
-                logBody.innerHTML = '<tr><td colspan="5">ログはありません</td></tr>';
+                logBody.innerHTML = '<tr id="summary-row"><td id="monthly-summary" colspan="5"></td></tr>' +
+                    '<tr><td colspan="5">ログはありません</td></tr>';
+                updateSummary();
             }
         });
         document.getElementById('download-logs').addEventListener('click', downloadLogs);
@@ -188,12 +190,16 @@
             document.getElementById('monthly-summary').textContent = summary;
         }
 
-        document.getElementById('show-summary').addEventListener('click', function () {
+
+        function updateSummary() {
             const value = document.getElementById('summary-month').value;
             if (!value) return;
             const [y, m] = value.split('-').map(Number);
             showMonthlySummary(y, m);
-        });
+        }
+
+        summaryMonth.addEventListener('change', updateSummary);
+        updateSummary();
 
     });
     </script>

--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
             "type": "image/png"
         }
     ], 
-    "version": "0.9j"
+    "version": "0.9k"
 }


### PR DESCRIPTION
## Summary
- 月別集計ボタンを削除し、選択された月の集計を自動表示
- 表の先頭行に常に集計結果を配置
- クリア時も集計行を維持
- バージョンを 0.9k へ更新

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685036026158832ebd17661edbb2a95b