### PR TITLE
ログ表示の曜日追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         <div style="padding-right: 20px;">
             <a href="https://forms.gle/fbZW4GG91BBKUmkc9" target="_blank">アンケートはこちら</a>
         </div>
-        <span>ver.0.9l</span>
+        <span>ver.0.9m</span>
     </div>
 
     <script src="scripts.js"></script>

--- a/logs.html
+++ b/logs.html
@@ -99,6 +99,12 @@
         const summaryMonth = document.getElementById('summary-month');
         const now = new Date();
         summaryMonth.value = now.toISOString().slice(0, 7);
+
+        function formatDateWithDay(dateStr) {
+            const d = new Date(dateStr);
+            const days = ['日', '月', '火', '水', '木', '金', '土'];
+            return `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}(${days[d.getDay()]})`;
+        }
         const data = localStorage.getItem('logs');
         if (data) {
             const daily = {};
@@ -110,7 +116,8 @@
             Object.keys(daily).sort().forEach(date => {
                 const { start, end, work, overtime } = daily[date];
                 const tr = document.createElement('tr');
-                [date, start, end, work, overtime].forEach(text => {
+                const row = [formatDateWithDay(date), start, end, work, overtime];
+                row.forEach(text => {
                     const td = document.createElement('td');
                     td.textContent = text;
                     tr.appendChild(td);

--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
             "type": "image/png"
         }
     ], 
-    "version": "0.9l"
+    "version": "0.9m"
 }


### PR DESCRIPTION
## Summary
- ログ画面の日付表示に曜日を追加
- バージョンを0.9mに更新

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851967e078c832ead7deee8b55be8e2