### PR TITLE
ログ表示を月変更に対応

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         <div style="padding-right: 20px;">
             <a href="https://forms.gle/fbZW4GG91BBKUmkc9" target="_blank">アンケートはこちら</a>
         </div>
-        <span>ver.0.9m</span>
+        <span>ver.0.9n</span>
     </div>
 
     <script src="scripts.js"></script>

--- a/logs.html
+++ b/logs.html
@@ -105,33 +105,6 @@
             const days = ['日', '月', '火', '水', '木', '金', '土'];
             return `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}(${days[d.getDay()]})`;
         }
-        const data = localStorage.getItem('logs');
-        if (data) {
-            const daily = {};
-            data.split('\n').forEach(line => {
-                if (!line) return;
-                const [date, start, end, work, overtime] = line.split(',');
-                daily[date] = { start, end, work, overtime };
-            });
-            Object.keys(daily).sort().forEach(date => {
-                const { start, end, work, overtime } = daily[date];
-                const tr = document.createElement('tr');
-                const row = [formatDateWithDay(date), start, end, work, overtime];
-                row.forEach(text => {
-                    const td = document.createElement('td');
-                    td.textContent = text;
-                    tr.appendChild(td);
-                });
-                logBody.appendChild(tr);
-            });
-        } else {
-            const tr = document.createElement('tr');
-            const td = document.createElement('td');
-            td.colSpan = 5;
-            td.textContent = 'ログはありません';
-            tr.appendChild(td);
-            logBody.appendChild(tr);
-        }
         document.getElementById('clear-logs').addEventListener('click', function () {
             if (confirm('ログをクリアしますか？')) {
                 localStorage.removeItem('logs');
@@ -156,6 +129,53 @@
             a.download = 'logs.csv';
             a.click();
             URL.revokeObjectURL(url);
+        }
+
+        function showMonthlyLogs(year, month) {
+            logBody.innerHTML = '';
+            const csv = localStorage.getItem('logs');
+            if (!csv) {
+                const tr = document.createElement('tr');
+                const td = document.createElement('td');
+                td.colSpan = 5;
+                td.textContent = 'ログはありません';
+                tr.appendChild(td);
+                logBody.appendChild(tr);
+                return;
+            }
+
+            const rows = [];
+            csv.split('\n').forEach(line => {
+                if (!line) return;
+                const [date, start, end, work, overtime] = line.split(',');
+                const d = new Date(date);
+                if (d.getFullYear() === year && d.getMonth() + 1 === month) {
+                    rows.push({ date, start, end, work, overtime });
+                }
+            });
+
+            rows.sort((a, b) => new Date(a.date) - new Date(b.date));
+
+            if (rows.length === 0) {
+                const tr = document.createElement('tr');
+                const td = document.createElement('td');
+                td.colSpan = 5;
+                td.textContent = 'ログはありません';
+                tr.appendChild(td);
+                logBody.appendChild(tr);
+                return;
+            }
+
+            rows.forEach(r => {
+                const tr = document.createElement('tr');
+                const row = [formatDateWithDay(r.date), r.start, r.end, r.work, r.overtime];
+                row.forEach(text => {
+                    const td = document.createElement('td');
+                    td.textContent = text;
+                    tr.appendChild(td);
+                });
+                logBody.appendChild(tr);
+            });
         }
 
         function showMonthlySummary(year, month) {
@@ -190,6 +210,7 @@
             const value = document.getElementById('summary-month').value;
             if (!value) return;
             const [y, m] = value.split('-').map(Number);
+            showMonthlyLogs(y, m);
             showMonthlySummary(y, m);
         }
 

--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
             "type": "image/png"
         }
     ], 
-    "version": "0.9m"
+    "version": "0.9n"
 }


### PR DESCRIPTION
## 概要
- ログ画面で集計対象年月を変更した際、表示するログをその月のみになるよう更新
- バージョンを 0.9n へ更新

## テスト結果
- `node test/test.js` を実行し、`All tests passed.` を確認


------
https://chatgpt.com/codex/tasks/task_e_685235eb07e0832eb4f43637cd502607