### PR TITLE
ログ画面の勤務時間表示を右寄せ

### DIFF
--- a/logs.html
+++ b/logs.html
@@ -64,6 +64,10 @@
             display: flex;
             gap: 8px;
         }
+        td:nth-child(4),
+        td:nth-child(5) {
+            text-align: right;
+        }
     </style>
 </head>
 <body>
@@ -86,8 +90,8 @@
                     <th style="border-bottom:1px solid #ccc; text-align:left;">日付</th>
                     <th style="border-bottom:1px solid #ccc; text-align:left;">始業</th>
                     <th style="border-bottom:1px solid #ccc; text-align:left;">終業</th>
-                    <th style="border-bottom:1px solid #ccc; text-align:left;">勤務時間</th>
-                    <th style="border-bottom:1px solid #ccc; text-align:left;">残業時間</th>
+                    <th style="border-bottom:1px solid #ccc; text-align:right;">勤務時間</th>
+                    <th style="border-bottom:1px solid #ccc; text-align:right;">残業時間</th>
                 </tr>
             </thead>
             <tbody id="log-body"></tbody>


### PR DESCRIPTION
## 変更内容
- ログ表示テーブルの勤務時間と残業時間を右寄せに変更

## テスト結果
- `npm test` を実行し、`All tests passed.` を確認

------
https://chatgpt.com/codex/tasks/task_e_68561d515008832e9f1403e54dbba1b8