### PR TITLE
残業時間の自動補正を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         <div style="padding-right: 20px;">
             <a href="https://forms.gle/fbZW4GG91BBKUmkc9" target="_blank">アンケートはこちら</a>
         </div>
-        <span>ver.0.9o</span>
+        <span>ver.0.9p</span>
     </div>
 
     <script src="scripts.js"></script>

--- a/logs.html
+++ b/logs.html
@@ -110,10 +110,41 @@
             return `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}(${days[d.getDay()]})`;
         }
 
+        function toMinutes(timeStr) {
+            const [h, m] = timeStr.split(':').map(Number);
+            return h * 60 + m;
+        }
+
+        function calculateWorkingHours(startTime, endTime) {
+            let totalMinutes = toMinutes(endTime) - toMinutes(startTime);
+            const breaks = [
+                { start: '11:45', end: '12:45' },
+                { start: '19:15', end: '19:45' }
+            ];
+            const workStart = toMinutes(startTime);
+            const workEnd = toMinutes(endTime);
+            breaks.forEach(b => {
+                const breakStart = toMinutes(b.start);
+                const breakEnd = toMinutes(b.end);
+                if (workStart < breakEnd && workEnd > breakStart) {
+                    const overlapStart = Math.max(workStart, breakStart);
+                    const overlapEnd = Math.min(workEnd, breakEnd);
+                    totalMinutes -= overlapEnd - overlapStart;
+                }
+            });
+            const workingHours = totalMinutes / 60;
+            return (Math.round(workingHours * 100) / 100).toFixed(2);
+        }
+
         function parseLogLine(line) {
             const simple = line.split(',');
             if (simple.length >= 5 && /^\d{4}-\d{2}-\d{2}$/.test(simple[0])) {
-                return simple.slice(0, 5).join(',');
+                const date = simple[0];
+                const start = simple[1];
+                const end = simple[2];
+                const work = calculateWorkingHours(start, end);
+                const overtime = (parseFloat(work) - 7.75).toFixed(2);
+                return `${date},${start},${end},${work},${overtime}`;
             }
             const parts = line.split(/,(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/);
             if (parts.length >= 4 && /^\d{4}-\d{2}-\d{2}T/.test(parts[0])) {
@@ -121,10 +152,10 @@
                 const date = body.match(/日付\s*(\d{4}-\d{2}-\d{2})/);
                 const start = body.match(/始業\s*(\d{2}:\d{2})/);
                 const end = body.match(/終業\s*(\d{2}:\d{2})/);
-                const work = parseFloat(parts[2]) || 0;
                 if (date && start && end) {
-                    const overtime = (work - 7.75).toFixed(2);
-                    return `${date[1]},${start[1]},${end[1]},${work.toFixed(2)},${overtime}`;
+                    const work = calculateWorkingHours(start[1], end[1]);
+                    const overtime = (parseFloat(work) - 7.75).toFixed(2);
+                    return `${date[1]},${start[1]},${end[1]},${work},${overtime}`;
                 }
             }
             return null;

--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
             "type": "image/png"
         }
     ], 
-    "version": "0.9o"
+    "version": "0.9p"
 }


### PR DESCRIPTION
## 概要
* logs.html で保存済みログの勤務時間から残業時間を再計算するように変更
* 新しい関数追加に伴いバージョンを 0.9p へ更新

## テスト結果
* `npm test --silent` を実行し、`All tests passed.` を確認

------
https://chatgpt.com/codex/tasks/task_e_6865018610c8832eb7f43e4da9437271