### PR TITLE
ログ保存処理の修正

### DIFF
--- a/logs.html
+++ b/logs.html
@@ -227,7 +227,18 @@
                 alert('ログはありません');
                 return;
             }
-            const lines = csv.split('\n').filter(line => line);
+            const daily = {};
+            csv.split('\n').forEach(line => {
+                if (!line) return;
+                const parts = line.split(',');
+                if (parts.length < 5) return;
+                const [date, start, end, work, overtime] = parts;
+                daily[date] = { start, end, work, overtime };
+            });
+            const lines = Object.keys(daily).sort().map(d => {
+                const { start, end, work, overtime } = daily[d];
+                return `${d},${start},${end},${work},${overtime}`;
+            });
             let totalWork = 0;
             let totalOvertime = 0;
             lines.forEach(line => {
@@ -259,17 +270,18 @@
                 return;
             }
 
-            const rows = [];
+            const daily = {};
             csv.split('\n').forEach(line => {
                 if (!line) return;
                 const [date, start, end, work, overtime] = line.split(',');
                 const d = new Date(date);
                 if (d.getFullYear() === year && d.getMonth() + 1 === month) {
-                    rows.push({ date, start, end, work, overtime });
+                    daily[date] = { start, end, work, overtime };
                 }
             });
 
-            rows.sort((a, b) => new Date(a.date) - new Date(b.date));
+            const rows = Object.keys(daily).map(d => ({ date: d, ...daily[d] }))
+                .sort((a, b) => new Date(a.date) - new Date(b.date));
 
             if (rows.length === 0) {
                 const tr = document.createElement('tr');


### PR DESCRIPTION
## 変更概要
- ログ保存時に重複行を除外していた処理を元に戻し、入力データを全て保持
- 表示と計算では日付ごとの重複を排除する実装は維持

## テスト結果
- `git diff --check` で問題ないことを確認
- ブラウザでの動作確認は未実施

------
https://chatgpt.com/codex/tasks/task_e_6865144ea620832e8328b7a588b2f140