### PR TITLE
Fix duplicate log display logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <div class="app-header">スマ勤サポートアプリ</div>
+    <div class="app-header">スマ勤サポートアプリ<span class="version">ver.0.9r</span></div>
     <div style="display: flex; justify-content: space-around;">
         <a href="manual.html" target="_blank">使い方</a>
         <a href="logs.html">ログ表示</a>
@@ -81,7 +81,6 @@
         <div style="padding-right: 20px;">
             <a href="https://forms.gle/fbZW4GG91BBKUmkc9" target="_blank">アンケートはこちら</a>
         </div>
-        <span>ver.0.9r</span>
     </div>
 
     <script src="scripts.js"></script>

--- a/logs.html
+++ b/logs.html
@@ -177,17 +177,17 @@
         const data = restoreLogsIfNeeded();
         if (data) {
             const daily = {};
-            const newLines = [];
+            const lines = [];
             data.split('\n').forEach(line => {
                 if (!line) return;
                 const parsed = parseLogLine(line);
                 if (!parsed) return;
                 const [date, start, end, work, overtime] = parsed.split(',');
                 daily[date] = { start, end, work, overtime };
-                newLines.push(parsed);
+                lines.push(parsed);
             });
-            if (newLines.length > 0) {
-                localStorage.setItem('logs', newLines.join('\n'));
+            if (lines.length > 0) {
+                localStorage.setItem('logs', lines.join('\n'));
             } else {
                 localStorage.removeItem('logs');
             }
@@ -227,25 +227,22 @@
                 alert('ログはありません');
                 return;
             }
+            const rawLines = csv.split('\n').filter(line => line);
             const daily = {};
-            csv.split('\n').forEach(line => {
-                if (!line) return;
+            rawLines.forEach(line => {
                 const parts = line.split(',');
                 if (parts.length < 5) return;
                 const [date, start, end, work, overtime] = parts;
                 daily[date] = { start, end, work, overtime };
             });
-            const lines = Object.keys(daily).sort().map(d => {
-                const { start, end, work, overtime } = daily[d];
-                return `${d},${start},${end},${work},${overtime}`;
-            });
             let totalWork = 0;
             let totalOvertime = 0;
-            lines.forEach(line => {
-                const parts = line.split(',');
-                totalWork += parseFloat(parts[3]) || 0;
-                totalOvertime += parseFloat(parts[4]) || 0;
+            Object.keys(daily).forEach(d => {
+                const { work, overtime } = daily[d];
+                totalWork += parseFloat(work) || 0;
+                totalOvertime += parseFloat(overtime) || 0;
             });
+            const lines = [...rawLines];
             lines.push(`Total,,,${totalWork.toFixed(2)},${totalOvertime.toFixed(2)}`);
             const header = 'Date,Start,End,Work Hours,Overtime\n';
             const blob = new Blob([header + lines.join('\n')], { type: 'text/csv' });

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,10 @@ body {
     text-align: center;
     font-size: 1.5em;
 }
+.version {
+    font-size: 0.7em;
+    margin-left: 8px;
+}
 
 .container {
     padding: 12px 8px;


### PR DESCRIPTION
## Summary
- 修正: ログ表示時にだけ日付を重複除外し、保存内容はそのまま保持
- CSV ダウンロードでは保存済みの行をそのまま出力し、合計値は最新情報から計算

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68651903e5f8832ea4ec2f34c268b2ea