### PR TITLE
Fix default date display on startup

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -216,7 +216,12 @@ document.addEventListener('DOMContentLoaded', function() {
         return date.toISOString().split('T')[0];
     }
 
-    dateInput.value = getDefaultDate();
+    function setDefaultDate() {
+        dateInput.value = getDefaultDate();
+    }
+
+    setDefaultDate();
+    window.addEventListener('pageshow', setDefaultDate);
 
     // 時刻の初期値を設定（ローカルストレージから取得）
     startTimeInput.value = localStorage.getItem('startTime') || "08:30";


### PR DESCRIPTION
## Summary
- show default date whenever the app is opened

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68688b725f10832ebbdab122f7e36f7a