### PR TITLE
Fix default date to return Date object

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <div class="app-header">スマ勤サポートアプリ<span class="version">ver.0.9u</span></div>
+    <div class="app-header">スマ勤サポートアプリ<span class="version">ver.0.9v</span></div>
     <div style="display: flex; justify-content: space-around;">
         <a href="manual.html" target="_blank">使い方</a>
         <a href="logs.html">ログ表示</a>

--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
             "type": "image/png"
         }
     ], 
-    "version": "0.9u"
+    "version": "0.9v"
 }

--- a/scripts.js
+++ b/scripts.js
@@ -213,11 +213,11 @@ document.addEventListener('DOMContentLoaded', function() {
         if (isHolidayDate(date)) {
             date = getNearestWeekday(date);
         }
-        return date.toISOString().split('T')[0];
+        return date;
     }
 
     function setDefaultDate() {
-        dateInput.value = getDefaultDate();
+        dateInput.valueAsDate = getDefaultDate();
     }
 
     setDefaultDate();


### PR DESCRIPTION
## Summary
- return a `Date` object from `getDefaultDate`
- assign default date via `valueAsDate`
- update version strings to v0.9v

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68688edf37b4832e9ff7011d1676335a