### PR TITLE
修正：日付処理をローカルタイム基準に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <div class="app-header">スマ勤サポートアプリ<span class="version">ver.0.9x</span></div>
+    <div class="app-header">スマ勤サポートアプリ<span class="version">ver.0.9y</span></div>
     <div style="display: flex; justify-content: space-around;">
         <a href="manual.html" target="_blank">使い方</a>
         <a href="logs.html">ログ表示</a>

--- a/logs.html
+++ b/logs.html
@@ -102,7 +102,8 @@
         const logBody = document.getElementById('log-body');
         const summaryMonth = document.getElementById('summary-month');
         const now = new Date();
-        summaryMonth.value = now.toISOString().slice(0, 7);
+        const month = String(now.getMonth() + 1).padStart(2, '0');
+        summaryMonth.value = `${now.getFullYear()}-${month}`;
 
         function formatDateWithDay(dateStr) {
             const d = new Date(dateStr);

--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
             "type": "image/png"
         }
     ], 
-    "version": "0.9x"
+    "version": "0.9y"
 }

--- a/scripts.js
+++ b/scripts.js
@@ -213,7 +213,10 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function formatDate(d) {
-        return d.toISOString().split('T')[0];
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
     }
 
     function setDefaultDate() {
@@ -338,7 +341,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (d.getDay() !== 0) return;
             do {
                 d.setDate(d.getDate() + 1);
-                const s = d.toISOString().split('T')[0];
+                const s = formatDate(d);
                 if (!holidays.has(s)) {
                     holidays.add(s);
                     return;
@@ -355,9 +358,9 @@ document.addEventListener('DOMContentLoaded', function() {
             const next = new Date(d);
             prev.setDate(prev.getDate() - 1);
             next.setDate(next.getDate() + 1);
-            const ds = d.toISOString().split('T')[0];
-            const prevStr = prev.toISOString().split('T')[0];
-            const nextStr = next.toISOString().split('T')[0];
+            const ds = formatDate(d);
+            const prevStr = formatDate(prev);
+            const nextStr = formatDate(next);
             if (!holidays.has(ds) && holidays.has(prevStr) && holidays.has(nextStr) && d.getDay() !== 0 && d.getDay() !== 6) {
                 holidays.add(ds);
             }
@@ -369,7 +372,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function isHolidayDate(date) {
         const holidays = getJapaneseHolidays(date.getFullYear());
-        const dateStr = date.toISOString().split('T')[0];
+        const dateStr = formatDate(date);
         if (holidays.has(dateStr)) return true;
         const day = date.getDay();
         return day === 0 || day === 6;
@@ -394,7 +397,7 @@ document.addEventListener('DOMContentLoaded', function() {
             while (isHolidayDate(d)) {
                 d.setDate(d.getDate() - 1);
             }
-            const str = d.toISOString().split('T')[0];
+            const str = formatDate(d);
             if (!loggedDates.has(str)) {
                 const m = d.getMonth() + 1;
                 const day = d.getDate();
@@ -436,7 +439,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // 現在の日付を取得
         const now = new Date();
-        const today = now.toISOString().split('T')[0];
+        const today = formatDate(now);
 
         // 今日以外の日付が指定された場合の警告表示
         if (selectedDate !== today) {
@@ -534,7 +537,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // 現在の日付を取得
         const now = new Date();
-        const today = now.toISOString().split('T')[0];
+        const today = formatDate(now);
 
         const selectedDateTime = new Date(`${selectedDate}T${selectedEndTime}`);
         if (selectedDateTime > now) {

--- a/test/summary.js
+++ b/test/summary.js
@@ -12,7 +12,10 @@ function computeMonthlySummary(csv, year, month) {
     const days = new Set();
     records.forEach(r => {
         if (r.date.getFullYear() === year && r.date.getMonth() + 1 === month) {
-            const dayStr = r.date.toISOString().split('T')[0];
+            const y = r.date.getFullYear();
+            const m = String(r.date.getMonth() + 1).padStart(2, '0');
+            const d = String(r.date.getDate()).padStart(2, '0');
+            const dayStr = `${y}-${m}-${d}`;
             days.add(dayStr);
             totalHours += r.hours;
         }


### PR DESCRIPTION
## 変更内容
- `toISOString()` 依存を廃止し、ローカルタイムで日付文字列を生成する `formatDate` を実装
- 祝日計算やログ確認など全体の処理を `formatDate` 使用に統一
- ログ画面の月選択初期化処理もローカルタイム基準に修正
- バージョンを `0.9y` へ更新

## テスト結果
- `node test/test.js` を実行し `All tests passed.` を確認


------
https://chatgpt.com/codex/tasks/task_e_686895ee31e4832e91e425d1ae5e7c65