### PR TITLE
Fix missing log warning timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <div class="app-header">スマ勤サポートアプリ<span class="version">ver.1.0.0</span></div>
+    <div class="app-header">スマ勤サポートアプリ<span class="version">ver.1.0.1</span></div>
     <div style="display: flex; justify-content: space-around;">
         <a href="manual.html" target="_blank">使い方</a>
         <a href="logs.html">ログ表示</a>

--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
             "type": "image/png"
         }
     ], 
-    "version": "1.0.0"
+    "version": "1.0.1"
 }

--- a/scripts.js
+++ b/scripts.js
@@ -384,6 +384,9 @@ document.addEventListener('DOMContentLoaded', function() {
     setDefaultDate();
     window.addEventListener('pageshow', setDefaultDate);
 
+    // 過去2回の平日ログの有無を確認し、欠落があれば警告を表示する。
+    // 引数: なし
+    // 戻り値: なし
     function checkMissingLogs() {
         const logsStr = restoreLogsIfNeeded() || '';
         const loggedDates = new Set();
@@ -620,7 +623,11 @@ document.addEventListener('DOMContentLoaded', function() {
         if (mailFormatInput) {
             mailFormatInput.checked = true;
         }
-        checkMissingLogs();
+        // 起動時のみ一度だけ入力漏れ警告を表示する
+        if (!sessionStorage.getItem('missingLogsChecked')) {
+            checkMissingLogs();
+            sessionStorage.setItem('missingLogsChecked', '1');
+        }
     });
 
     // サービスワーカーが変更された場合の処理


### PR DESCRIPTION
## Summary
- alert about missing logs only once per app startup
- update version to 1.0.1

## Testing
- `npm test --silent`
- `node test/test.js`


------
https://chatgpt.com/codex/tasks/task_e_686c6274fe28832eab266c744c822faf