### PR TITLE
編集ボタンのサイズを縮小

### DIFF
--- a/logs.html
+++ b/logs.html
@@ -59,6 +59,10 @@
             font-size: 10px;
             flex-grow: 0;
         }
+        .tiny {
+            padding: 2px 6px;
+            font-size: 10px;
+        }
         button:hover {
             background-color: #3a4d57;
         }
@@ -302,7 +306,8 @@
                 });
                 const opTd = document.createElement('td');
                 const editBtn = document.createElement('button');
-                editBtn.textContent = '編集';
+                editBtn.textContent = '✎';
+                editBtn.title = '編集';
                 editBtn.className = 'tiny';
                 editBtn.addEventListener('click', enterEdit);
                 opTd.appendChild(editBtn);


### PR DESCRIPTION
## 変更内容
- ログ画面の編集ボタンをアイコン表示に変更し、`.tiny` クラスの汎用スタイルを追加して小型化

## テスト結果
- `node test/test.js` で全テスト成功【88c35c†L1-L3】

------
https://chatgpt.com/codex/tasks/task_e_686f6407cd2c832ebf3daae1b6f1a903