### PR TITLE
Fix log edit icon alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <div class="app-header">スマ勤サポートアプリ<span class="version">ver.1.1.1</span></div>
+    <div class="app-header">スマ勤サポートアプリ<span class="version">ver.1.1.2</span></div>
     <div class="container">
         <div id="refresh-indicator">更新中...</div>
 

--- a/logs.html
+++ b/logs.html
@@ -75,8 +75,15 @@
             gap: 8px;
         }
         td:nth-child(4),
-        td:nth-child(5) {
+        td:nth-child(5),
+        td:nth-child(6) {
             text-align: right;
+            vertical-align: middle;
+        }
+        .edit-btn {
+            margin-top: 0;
+            background-color: #fff;
+            color: #333;
         }
     </style>
 </head>
@@ -308,7 +315,7 @@
                 const editBtn = document.createElement('button');
                 editBtn.textContent = '✎';
                 editBtn.title = '編集';
-                editBtn.className = 'tiny';
+                editBtn.className = 'tiny edit-btn';
                 editBtn.addEventListener('click', enterEdit);
                 opTd.appendChild(editBtn);
                 tr.appendChild(opTd);

--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
             "type": "image/png"
         }
     ], 
-    "version": "1.1.1"
+    "version": "1.1.2"
 }


### PR DESCRIPTION
## Summary
- fix edit icon alignment on log screen
- right-align edit icon and use white background
- bump version to 1.1.2

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f6de54b98832ea7bfaaca2f908208