### PR TITLE
ログ画面更新機能追加

### DIFF
--- a/logs.html
+++ b/logs.html
@@ -541,6 +541,19 @@
         updateSummary();
 
     });
+
+    /**
+     * 更新要求を受け取ったら画面をリロードする。
+     * @param {StorageEvent} e - storageイベント
+     * @returns {void}
+     */
+    function handleRefreshRequest(e) {
+        if (e.key === 'refreshLogs') {
+            location.reload();
+        }
+    }
+
+    window.addEventListener('storage', handleRefreshRequest);
     </script>
 </body>
 </html>

--- a/scripts.js
+++ b/scripts.js
@@ -163,6 +163,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const reg = await navigator.serviceWorker.getRegistration();
             reg?.update();
         }
+        localStorage.setItem('refreshLogs', Date.now().toString());
         refreshIndicator.style.display = 'block';
         setTimeout(() => location.reload(), 1500);
     });


### PR DESCRIPTION
## 変更概要
- 更新ボタンを押した際にログ画面も自動リロードされるよう対応
- `logs.html` にストレージイベントを監視する関数を追加
- `scripts.js` の更新ボタン処理でローカルストレージに通知を送信

## テスト結果
- `npm test` 実行で既存テストが成功することを確認
```
> sumakin@0.1.0 test
> node test/test.js

All tests passed.
```


------
https://chatgpt.com/codex/tasks/task_e_686f7082f154832e8047677062b7bfbb