### PR TITLE
ログ編集時のカレンダー誤表示を修正

### DIFF
--- a/logs.html
+++ b/logs.html
@@ -222,7 +222,8 @@
                 const start = simple[1];
                 const end = simple[2];
                 if (start === '年休') {
-                    return `${date},年休,年休,0.00,0.00`;
+                    // 年休の場合は 8:30-17:15 勤務として扱う
+                    return `${date},年休,年休,7.75,0.00`;
                 }
                 const work = simple[3];
                 const overtime = simple[4];
@@ -347,8 +348,14 @@
         function openEditDialog(date, start, end) {
             originalDate = date;
             editDate.value = date;
-            editStart.value = start;
-            editEnd.value = end;
+            if (start === '年休') {
+                // 年休はデフォルト時間を入力欄に設定する
+                editStart.value = '08:30';
+                editEnd.value = '17:15';
+            } else {
+                editStart.value = start;
+                editEnd.value = end;
+            }
             editDialog.showModal();
             editDialog.focus();
         }
@@ -377,7 +384,9 @@
                 editBtn.textContent = '✎';
                 editBtn.title = '編集';
                 editBtn.className = 'tiny edit-btn';
-                editBtn.addEventListener('click', function () {
+                editBtn.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
                     openEditDialog(date, start, end);
                 });
                 opTd.appendChild(editBtn);

--- a/scripts.js
+++ b/scripts.js
@@ -24,16 +24,19 @@ document.addEventListener('DOMContentLoaded', function() {
 
     /**
      * 休暇チェック状態に応じて入力欄の有効／無効を切り替える。
+     * 違う項目を直接チェックした場合でも切り替えられるようにする。
+     * @param {Event} e changeイベント
      * @returns {void}
      */
-    function updateLeaveControls() {
-        if (annualLeaveCheckbox.checked) {
+    function updateLeaveControls(e) {
+        const target = e?.target;
+        if (target === annualLeaveCheckbox && annualLeaveCheckbox.checked) {
             amLeaveCheckbox.checked = false;
             pmLeaveCheckbox.checked = false;
-        } else if (amLeaveCheckbox.checked) {
+        } else if (target === amLeaveCheckbox && amLeaveCheckbox.checked) {
             annualLeaveCheckbox.checked = false;
             pmLeaveCheckbox.checked = false;
-        } else if (pmLeaveCheckbox.checked) {
+        } else if (target === pmLeaveCheckbox && pmLeaveCheckbox.checked) {
             annualLeaveCheckbox.checked = false;
             amLeaveCheckbox.checked = false;
         }
@@ -647,7 +650,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const totalTaskHours = calculateTotalTaskHours();
 
         if (annualLeaveCheckbox.checked) {
-            saveLog(selectedDate, '年休', '年休', '0.00', '0.00');
+            saveLog(selectedDate, '年休', '年休', '7.75', '0.00');
             alert('年休を登録しました');
             saveTaskData();
             return;


### PR DESCRIPTION
## 概要
- 年休ログ読込時に勤務時間が0となっていたため7.75時間として扱うよう修正
- 年休のログを編集する際はデフォルトで8:30-17:15を表示

## テスト結果
- `npm test` 実行し全テスト成功

------
https://chatgpt.com/codex/tasks/task_e_6871ad4e8714832ea281b690ab83d967